### PR TITLE
Fix USDT allowance

### DIFF
--- a/src/Contexts/ChainbridgeContext.tsx
+++ b/src/Contexts/ChainbridgeContext.tsx
@@ -372,7 +372,7 @@ const ChainbridgeProvider = ({ children }: IChainbridgeContextProps) => {
         homeChain.erc20HandlerAddress
       );
 
-      if (Number(utils.formatUnits(currentAllowance)) < amount) {
+      if (Number(utils.formatUnits(currentAllowance, decimals)) < amount) {
         await (
           await erc20.approve(
             homeChain.erc20HandlerAddress,


### PR DESCRIPTION
USDT includes [strange allowance logic](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7#code), here is a snippet of their `approve` function

```
    /**
    * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
    * @param _spender The address which will spend the funds.
    * @param _value The amount of tokens to be spent.
    */
    function approve(address _spender, uint _value) public onlyPayloadSize(2 * 32) {

        // To change the approve amount you first have to reduce the addresses`
        //  allowance to zero by calling `approve(_spender, 0)` if it is not
        //  already 0 to mitigate the race condition described here:
        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
        require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));

        allowed[msg.sender][_spender] = _value;
        Approval(msg.sender, _spender, _value);
    }
```

To work around this, we must reset the user's approval to 0 if they have an approval already that is too low. 

This PR also fixes a small bug that did not consider decimals when checking if the user already has the correct amount of allowance.