### PR TITLE
Change discord link to telegram

### DIFF
--- a/src/Modules/AboutDrawer.tsx
+++ b/src/Modules/AboutDrawer.tsx
@@ -56,10 +56,10 @@ const AboutDrawer: React.FC<IAboutDrawerProps> = ({
         </Button>
         <a
           rel="noopener noreferrer"
-          href="https://discord.com/invite/n2U6x9c"
+          href="https://t.me/avalancheavax"
           target="_blank"
         >
-          <Button variant="outline">Ask a question on Discord</Button>
+          <Button variant="outline">Ask a question on Telegram</Button>
         </a>
       </section>
     </CustomDrawer>

--- a/src/Modules/ChangeNetworkDrawer.tsx
+++ b/src/Modules/ChangeNetworkDrawer.tsx
@@ -68,10 +68,10 @@ const ChangeNetworkDrawer: React.FC<IChangeNetworkDrawerProps> = ({
         </Button>
         <a
           rel="noopener noreferrer"
-          href="https://discord.com/invite/n2U6x9c"
+          href="https://t.me/avalancheavax"
           target="_blank"
         >
-          <Button variant="outline">Ask a question on Discord</Button>
+          <Button variant="outline">Ask a question on Telegram</Button>
         </a>
       </section>
     </CustomDrawer>

--- a/src/Modules/NetworkUnsupportedModal.tsx
+++ b/src/Modules/NetworkUnsupportedModal.tsx
@@ -118,11 +118,11 @@ const NetworkUnsupportedModal: React.FC<INetworkUnsupportedModalProps> = ({
         <section className={classes.buttons}>
           <a
             rel="noopener noreferrer"
-            href="https://discord.com/invite/n2U6x9c"
+            href="https://t.me/avalancheavax"
             target="_blank"
           >
             <Button size="small" className={classes.button} variant="outline">
-              Ask a question on Discord
+              Ask a question on Telegram
             </Button>
           </a>
         </section>

--- a/src/Modules/TransferActiveModal.tsx
+++ b/src/Modules/TransferActiveModal.tsx
@@ -299,7 +299,7 @@ const TransferActiveModal: React.FC<ITransferActiveModalProps> = ({
               </Button>
               <a
                 rel="noopener noreferrer"
-                href="https://discord.com/invite/n2U6x9c"
+                href="https://t.me/avalancheavax"
                 target="_blank"
               >
                 <Button
@@ -307,7 +307,7 @@ const TransferActiveModal: React.FC<ITransferActiveModalProps> = ({
                   className={classes.button}
                   variant="outline"
                 >
-                  Ask a question on Discord
+                  Ask a question on Telegram
                 </Button>
               </a>
             </section>


### PR DESCRIPTION
Hey the help link went to ChainSafe's discord channel, I changed it to go to Ava Labs' telegram.